### PR TITLE
Readme: CLI: `node outliner ...` > `outliner ...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm install @davestewart/outliner --global
 To start converting, call the `outliner` service passing `source` and (optional) `target` paths:
 
 ```
-node outliner <source> <target>
+outliner <source> <target>
 ```
 
 Note:
@@ -82,7 +82,7 @@ Note:
 - To remove `width` and `height` information (so they resize nicely) pass the `--autosize` flag:
 
 ```
-node outliner <source> <target> --autosize
+outliner <source> <target> --autosize
 ```
 
 ### As a project service
@@ -104,7 +104,7 @@ Then, add a script entry to your project's `package.json`, e.g.:
 ```json
 {
   "scripts": {
-    "outline-icons": "node outliner <source> <target> --autosize"
+    "outline-icons": "outliner <source> <target> --autosize"
   }
 }
 ```


### PR DESCRIPTION
Maybe I'm missing something, but global npm scripts run without the prefix `node [bin]` (see https://github.com/davestewart/outliner/blob/277b690aeda8a3b61ebbffe1c9a7cd0c9f98ad57/package.json#L7C10-L7C10). The command you supplied executes a file called `outliner.js` in the current local dir.

The same goes for the command inside the package.json scripts, there the package doesn't have to be globally installed though, as running the command as a package.json script alters the `PATH` temporary.  

Alternatively, you could write `npx outliner ...`, which would install the script globally if needed. Then you could skip the installation instruction.